### PR TITLE
Ready for Release 3.2.5

### DIFF
--- a/apivalidation/pom.xml
+++ b/apivalidation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>apivalidation</artifactId>

--- a/apivalidation/pom.xml
+++ b/apivalidation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>apivalidation</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/geo/pom.xml
+++ b/geo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>geo</artifactId>

--- a/geo/pom.xml
+++ b/geo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>geo</artifactId>

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
@@ -114,6 +114,8 @@ public final class Geo {
      * Calculate the shortest distance between GeoPoints. This is an approximation, that works fine for relative small
      * distances, say up to 200km.
      *
+     * Note that the elevation of points is NOT taken into account. It is the 2D distance only.
+     *
      * @param p1 Point 1.
      * @param p2 Point 2.
      * @return Distance, always &gt;= 0.

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
@@ -29,9 +29,9 @@ import javax.annotation.Nullable;
  */
 public final class Geo {
 
-    // Radius of Earth.
+    // Radius of Earth, as used by WGS84.
     public static final double EARTH_RADIUS_X_METERS = 6378137.0;
-    public static final double EARTH_RADIUS_Y_METERS = 6356752.3;
+    public static final double EARTH_RADIUS_Y_METERS = 6356752.3142;
 
     // Circumference of Earth.
     public static final double EARTH_CIRCUMFERENCE_X = EARTH_RADIUS_X_METERS * 2.0 * Math.PI;

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
@@ -145,9 +145,14 @@ public final class Geo {
         // Meters per longitude is fixed; per latitude requires * cos(avg(lat)).
         final double deltaXMeters = degreesLonToMetersAtLat(deltaLonDegrees, avgLat);
         final double deltaYMeters = degreesLatToMeters(deltaLatDegrees);
+        Double deltaElevationMeters = p1.getElevationMetersOrNaN() - p2.getElevationMetersOrNaN();
+        if (deltaElevationMeters.isNaN()) {
+            deltaElevationMeters = 0.0;
+        }
 
         // Calculate length through Earth. This is an approximation, but works fine for short distances.
-        final double len = Math.sqrt((deltaXMeters * deltaXMeters) + (deltaYMeters * deltaYMeters));
+        final double len = Math.sqrt((deltaXMeters * deltaXMeters) + (deltaYMeters * deltaYMeters) +
+                (deltaElevationMeters * deltaElevationMeters));
         assert len >= 0.0;
         return len;
     }

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoArea.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoArea.java
@@ -71,7 +71,7 @@ public abstract class GeoArea extends GeoObject {
     public GeoPoint getCenter() {
         final GeoPoint southWest = boundingBox().getSouthWest();
         final GeoPoint northEast = boundingBox().getNorthEast();
-        final double elevationMeters = (southWest.getElevationMeters() + northEast.getElevationMeters()) / 2.0;
+        final double elevationMeters = (southWest.getElevationMetersOrNaN() + northEast.getElevationMetersOrNaN()) / 2.0;
         final GeoLine southNorth = new GeoLine(
                 new GeoPoint(southWest.getLat(), 0.0),
                 new GeoPoint(northEast.getLat(), 0.0));

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoArea.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoArea.java
@@ -69,17 +69,20 @@ public abstract class GeoArea extends GeoObject {
     @Override
     @Nonnull
     public GeoPoint getCenter() {
+        final GeoPoint southWest = boundingBox().getSouthWest();
+        final GeoPoint northEast = boundingBox().getNorthEast();
+        final double elevationMeters = (southWest.getElevationMeters() + northEast.getElevationMeters()) / 2.0;
         final GeoLine southNorth = new GeoLine(
-                new GeoPoint(boundingBox().getSouthWest().getLat(), 0.0),
-                new GeoPoint(boundingBox().getNorthEast().getLat(), 0.0));
+                new GeoPoint(southWest.getLat(), 0.0),
+                new GeoPoint(northEast.getLat(), 0.0));
 
         final GeoLine westEast = new GeoLine(
-                new GeoPoint(0.0, boundingBox().getSouthWest().getLon()),
-                new GeoPoint(0.0, boundingBox().getNorthEast().getLon()));
+                new GeoPoint(0.0, southWest.getLon()),
+                new GeoPoint(0.0, northEast.getLon()));
 
         final double centerLat = southNorth.getCenter().getLat();
         final double centerLon = westEast.getCenter().getLon();
-        return new GeoPoint(centerLat, centerLon);
+        return new GeoPoint(centerLat, centerLon, elevationMeters);
     }
 
     /**

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoCircle.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoCircle.java
@@ -191,7 +191,7 @@ public final class GeoCircle extends Primitive {
 
     @Nonnull
     private GeoRectangle calcBoundingBox(final double c) {
-        final double elevationMeters = center.getElevationMeters();
+        final double elevationMeters = center.getElevationMetersOrNaN();
         final double lowerLeftLat = center.getLat() - (Geo.metersToDegreesLat(radiusMeters) * c);
         final double lowerLeftLon = center.getLon() - (Geo.metersToDegreesLonAtLat(radiusMeters, center.getLat()) * c);
         final double upperRightLat = center.getLat() + (Geo.metersToDegreesLat(radiusMeters) * c);

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoCircle.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoCircle.java
@@ -191,13 +191,14 @@ public final class GeoCircle extends Primitive {
 
     @Nonnull
     private GeoRectangle calcBoundingBox(final double c) {
+        final double elevationMeters = center.getElevationMeters();
         final double lowerLeftLat = center.getLat() - (Geo.metersToDegreesLat(radiusMeters) * c);
         final double lowerLeftLon = center.getLon() - (Geo.metersToDegreesLonAtLat(radiusMeters, center.getLat()) * c);
         final double upperRightLat = center.getLat() + (Geo.metersToDegreesLat(radiusMeters) * c);
         final double upperRightLon = center.getLon() + Geo.metersToDegreesLonAtLat(radiusMeters, center.getLat() * c);
         return new GeoRectangle(
-                new GeoPoint(lowerLeftLat, lowerLeftLon),
-                new GeoPoint(upperRightLat, upperRightLon));
+                new GeoPoint(lowerLeftLat, lowerLeftLon, elevationMeters),
+                new GeoPoint(upperRightLat, upperRightLon, elevationMeters));
     }
 
     @Override

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
@@ -92,7 +92,7 @@ public final class GeoLine extends GeoObject {
         final double lon = (((northEast.getLon() >= southWest.getLon()) ?
                 (northEast.getLon()) : ((northEast.getLon() + 360.0))) +
                 southWest.getLon()) / 2.0;
-        final double elevationMeters = (southWest.getElevationMeters() + northEast.getElevationMeters()) / 2.0;
+        final double elevationMeters = (southWest.getElevationMetersOrNaN() + northEast.getElevationMetersOrNaN()) / 2.0;
 
         // The elevationMeters may be NaN, which is fine.
         return new GeoPoint(lat, lon, elevationMeters);

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
@@ -92,7 +92,10 @@ public final class GeoLine extends GeoObject {
         final double lon = (((northEast.getLon() >= southWest.getLon()) ?
                 (northEast.getLon()) : ((northEast.getLon() + 360.0))) +
                 southWest.getLon()) / 2.0;
-        return new GeoPoint(lat, lon);
+        final double elevationMeters = (southWest.getElevationMeters() + northEast.getElevationMeters()) / 2.0;
+
+        // The elevationMeters may be NaN, which is fine.
+        return new GeoPoint(lat, lon, elevationMeters);
     }
 
     /**

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
@@ -127,25 +127,25 @@ public final class GeoPoint extends GeoObject {
     }
 
     /**
-     * Get elevation (in meters).
+     * Get elevation (in meters), or NaN if the elevation is absent.
+     * Note that the return cannot be null!
      *
-     * @return Elevantion in meters.
+     * @return Elevation in meters, or NaN if absent. It is never null!
      */
-    @Nullable
+    @Nonnull
     public Double getElevationMeters() {
-        return elevationMeters;
+        return (elevationMeters == null) ? Double.NaN : elevationMeters;
     }
 
     /**
-     * Get elevation (in meters), or NaN if the elevation is absent.
-     * This is a convenience method if you wish to avoid checking
-     * for null everywhere, or getting warnings for nullability.
+     * Get elevation (in meters).
+     * Normally, you should probably use {@link #getElevationMeters()}.
      *
-     * @return Elevantion in meters, or NaN if absent.
+     * @return Elevation in meters, or null, if no elevation is present.
      */
-    @Nonnull
-    public Double getElevationMetersOrNaN() {
-        return (elevationMeters == null) ? Double.NaN : elevationMeters;
+    @Nullable
+    public Double getElevationMetersOrNull() {
+        return elevationMeters;
     }
 
     /**

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
@@ -130,7 +130,9 @@ public final class GeoPoint extends GeoObject {
      * Get elevation (in meters), or NaN if the elevation is absent.
      * Note that the return cannot be null!
      *
-     * @return Elevation in meters, or NaN if absent. It is never null!
+     * @return Elevation in meters, or NaN if absent. The return value is never null! This allows
+     * the caller to "do the math", like adding or averaging elevations, even if they don't exist
+     * for all points, because once NaN is used in an expression, the result will be NaN as well.
      */
     @Nonnull
     public Double getElevationMeters() {
@@ -171,9 +173,9 @@ public final class GeoPoint extends GeoObject {
     }
 
     /**
-     * Setter for {@link #getElevationMeters()} ()}.
+     * Setter for {@link #getElevationMeters()}.
      *
-     * @param elevationMeters Elevation in meters. If null, the elevation is omitted.
+     * @param elevationMeters Elevation in meters. If null or NaN, the elevation is omitted.
      * @return New point.
      */
     @Nonnull

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
@@ -135,18 +135,18 @@ public final class GeoPoint extends GeoObject {
      * for all points, because once NaN is used in an expression, the result will be NaN as well.
      */
     @Nonnull
-    public Double getElevationMeters() {
+    public Double getElevationMetersOrNaN() {
         return (elevationMeters == null) ? Double.NaN : elevationMeters;
     }
 
     /**
      * Get elevation (in meters).
-     * Normally, you should probably use {@link #getElevationMeters()}.
+     * Normally, you should probably use {@link #getElevationMetersOrNaN()}.
      *
      * @return Elevation in meters, or null, if no elevation is present.
      */
     @Nullable
-    public Double getElevationMetersOrNull() {
+    public Double getElevationMeters() {
         return elevationMeters;
     }
 
@@ -173,7 +173,7 @@ public final class GeoPoint extends GeoObject {
     }
 
     /**
-     * Setter for {@link #getElevationMeters()}.
+     * Setter for {@link #getElevationMetersOrNaN()}.
      *
      * @param elevationMeters Elevation in meters. If null or NaN, the elevation is omitted.
      * @return New point.

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
@@ -144,7 +144,7 @@ public final class GeoPoint extends GeoObject {
      * @return Elevantion in meters, or NaN if absent.
      */
     @Nonnull
-    public Double getElevationMetersOrNan() {
+    public Double getElevationMetersOrNaN() {
         return (elevationMeters == null) ? Double.NaN : elevationMeters;
     }
 

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -71,15 +71,20 @@ public final class GeoPolyLine extends GeoObject {
 
     /**
      * Return center == Mid point of bounding box of polyline.
+     * The elevation of the center point is defined as the average of all elevations of its points.
+     * if any of the elevations is undefined, this one will be too.
      *
      * @return Center.
      */
     @Nonnull
     @Override
     public GeoPoint getCenter() {
+        assert !points.isEmpty();
+        double elevationMeters = 0.0;
         GeoPoint southWest = points.get(0);
         GeoPoint northEast = points.get(0);
         for (final GeoPoint point : points) {
+            elevationMeters = elevationMeters + point.getElevationMeters();
             final GeoLine sw = new GeoLine(southWest, point);
             if (sw.isWrappedOnLongSide()) {
                 southWest = southWest.withLon(point.getLon());
@@ -99,7 +104,8 @@ public final class GeoPolyLine extends GeoObject {
         }
         final GeoPoint center = new GeoPoint(
                 (southWest.getLat() + northEast.getLat()) / 2.0,
-                (southWest.getLon() + northEast.getLon()) / 2.0);
+                (southWest.getLon() + northEast.getLon()) / 2.0,
+                elevationMeters / points.size());
         return center;
     }
 

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -84,7 +84,7 @@ public final class GeoPolyLine extends GeoObject {
         GeoPoint southWest = points.get(0);
         GeoPoint northEast = points.get(0);
         for (final GeoPoint point : points) {
-            elevationMeters = elevationMeters + point.getElevationMeters();
+            elevationMeters = elevationMeters + point.getElevationMetersOrNaN();
             final GeoLine sw = new GeoLine(southWest, point);
             if (sw.isWrappedOnLongSide()) {
                 southWest = southWest.withLon(point.getLon());

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -2,7 +2,8 @@
  * Copyright (C) 2012-2017. TomTom International BV (http://tomtom.com).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * you may not use this
+file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -2,8 +2,7 @@
  * Copyright (C) 2012-2017. TomTom International BV (http://tomtom.com).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this
-file except in compliance with the License.
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
@@ -206,8 +206,8 @@ public final class GeoRectangle extends Primitive {
         final double latDelta = Geo.metersToDegreesLat(meters);
         final double southLonDelta = Geo.metersToDegreesLonAtLat(meters, southWest.getLat());
         final double northLonDelta = Geo.metersToDegreesLonAtLat(meters, northEast.getLat());
-        return withSouthWest(new GeoPoint(southWest.getLat() - latDelta, southWest.getLon() - southLonDelta)).
-                withNorthEast(new GeoPoint(northEast.getLat() + latDelta, northEast.getLon() + northLonDelta));
+        return withSouthWest(new GeoPoint(southWest.getLat() - latDelta, southWest.getLon() - southLonDelta, southWest.getElevationMeters())).
+                withNorthEast(new GeoPoint(northEast.getLat() + latDelta, northEast.getLon() + northLonDelta, northEast.getElevationMeters()));
     }
 
     @Override
@@ -283,9 +283,9 @@ public final class GeoRectangle extends Primitive {
         final Collection<GeoRectangle> rects = new ArrayList<>();
         if (isWrapped()) {
             final GeoRectangle west = new GeoRectangle(
-                    new GeoPoint(southWest.getLat(), -180.0), northEast);
+                    new GeoPoint(southWest.getLat(), -180.0, southWest.getElevationMeters()), northEast);
             final GeoRectangle east = new GeoRectangle(
-                    southWest, new GeoPoint(northEast.getLat(), Geo.LON180));
+                    southWest, new GeoPoint(northEast.getLat(), Geo.LON180, northEast.getElevationMeters()));
             rects.add(west);
             rects.add(east);
         } else {
@@ -304,8 +304,26 @@ public final class GeoRectangle extends Primitive {
      */
     @Nonnull
     public GeoRectangle grow(@Nonnull final GeoPoint point) {
-        final double newSouthWestLat = Math.min(southWest.getLat(), point.getLat());
-        final double newNorthEastLat = Math.max(northEast.getLat(), point.getLat());
+        final double newSouthWestLat;
+        final double newNorthEastLat;
+        final double newSouthWestElevationMeters;
+        final double newNorthEastElevationMeters;
+
+        if (southWest.getLat() < point.getLat()) {
+            newSouthWestLat = southWest.getLat();
+            newSouthWestElevationMeters = southWest.getElevationMeters();
+        } else {
+            newSouthWestLat = point.getLat();
+            newSouthWestElevationMeters = point.getElevationMeters();
+        }
+
+        if (northEast.getLat() > point.getLat()) {
+            newNorthEastLat = northEast.getLat();
+            newNorthEastElevationMeters = northEast.getElevationMeters();
+        } else {
+            newNorthEastLat = point.getLat();
+            newNorthEastElevationMeters = point.getElevationMeters();
+        }
 
         final double newSouthWestLon1;
         final double newNorthEastLon1;
@@ -330,11 +348,11 @@ public final class GeoRectangle extends Primitive {
 
         // Simply try both rectangles.
         final GeoRectangle rect1 = new GeoRectangle(
-                new GeoPoint(newSouthWestLat, newSouthWestLon1),
-                new GeoPoint(newNorthEastLat, newNorthEastLon1));
+                new GeoPoint(newSouthWestLat, newSouthWestLon1, newSouthWestElevationMeters),
+                new GeoPoint(newNorthEastLat, newNorthEastLon1, newNorthEastElevationMeters));
         final GeoRectangle rect2 = new GeoRectangle(
-                new GeoPoint(newSouthWestLat, newSouthWestLon2),
-                new GeoPoint(newNorthEastLat, newNorthEastLon2));
+                new GeoPoint(newSouthWestLat, newSouthWestLon2, newSouthWestElevationMeters),
+                new GeoPoint(newNorthEastLat, newNorthEastLon2, newNorthEastElevationMeters));
         final GeoRectangle rect3 = new GeoRectangle(
                 southWest.withLat(newSouthWestLat),
                 northEast.withLat(newNorthEastLat));

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
@@ -206,8 +206,8 @@ public final class GeoRectangle extends Primitive {
         final double latDelta = Geo.metersToDegreesLat(meters);
         final double southLonDelta = Geo.metersToDegreesLonAtLat(meters, southWest.getLat());
         final double northLonDelta = Geo.metersToDegreesLonAtLat(meters, northEast.getLat());
-        return withSouthWest(new GeoPoint(southWest.getLat() - latDelta, southWest.getLon() - southLonDelta, southWest.getElevationMeters())).
-                withNorthEast(new GeoPoint(northEast.getLat() + latDelta, northEast.getLon() + northLonDelta, northEast.getElevationMeters()));
+        return withSouthWest(new GeoPoint(southWest.getLat() - latDelta, southWest.getLon() - southLonDelta, southWest.getElevationMetersOrNaN())).
+                withNorthEast(new GeoPoint(northEast.getLat() + latDelta, northEast.getLon() + northLonDelta, northEast.getElevationMetersOrNaN()));
     }
 
     @Override
@@ -283,9 +283,9 @@ public final class GeoRectangle extends Primitive {
         final Collection<GeoRectangle> rects = new ArrayList<>();
         if (isWrapped()) {
             final GeoRectangle west = new GeoRectangle(
-                    new GeoPoint(southWest.getLat(), -180.0, southWest.getElevationMeters()), northEast);
+                    new GeoPoint(southWest.getLat(), -180.0, southWest.getElevationMetersOrNaN()), northEast);
             final GeoRectangle east = new GeoRectangle(
-                    southWest, new GeoPoint(northEast.getLat(), Geo.LON180, northEast.getElevationMeters()));
+                    southWest, new GeoPoint(northEast.getLat(), Geo.LON180, northEast.getElevationMetersOrNaN()));
             rects.add(west);
             rects.add(east);
         } else {
@@ -311,18 +311,18 @@ public final class GeoRectangle extends Primitive {
 
         if (southWest.getLat() < point.getLat()) {
             newSouthWestLat = southWest.getLat();
-            newSouthWestElevationMeters = southWest.getElevationMeters();
+            newSouthWestElevationMeters = southWest.getElevationMetersOrNaN();
         } else {
             newSouthWestLat = point.getLat();
-            newSouthWestElevationMeters = point.getElevationMeters();
+            newSouthWestElevationMeters = point.getElevationMetersOrNaN();
         }
 
         if (northEast.getLat() > point.getLat()) {
             newNorthEastLat = northEast.getLat();
-            newNorthEastElevationMeters = northEast.getElevationMeters();
+            newNorthEastElevationMeters = northEast.getElevationMetersOrNaN();
         } else {
             newNorthEastLat = point.getLat();
-            newNorthEastElevationMeters = point.getElevationMeters();
+            newNorthEastElevationMeters = point.getElevationMetersOrNaN();
         }
 
         final double newSouthWestLon1;

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/Position3D.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/Position3D.java
@@ -24,6 +24,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * This class is deprecated. Thew class GeoPoint has been enhanced to
+ * allow an elevation as well.
+ */
+@Deprecated
 @Immutable
 public class Position3D implements JsonRenderable {
     @Nonnull

--- a/geo/src/main/java/com/tomtom/speedtools/tilemap/MapConst.java
+++ b/geo/src/main/java/com/tomtom/speedtools/tilemap/MapConst.java
@@ -94,27 +94,27 @@ public final class MapConst {
     public final static int ZOOM_LEVELS = 18;
 
     /**
-     * How many tiles across (or down) is the world at this zoom.
+     * How many tiles is the world at this zoom in total.
      */
     public final static long[] TILES_PER_ZOOM = {
-            1,
-            4,
-            16,
-            64,
-            256,
-            1024,
-            4096,
-            16384,
-            65536,
-            262144,
-            1048576,
-            4194304,
-            16777216,
-            67108864,
-            268435456,
-            1073741824,
-            4294967296L,
-            17179869184L
+            1,              // Level 0
+            4,              // Level 1
+            16,             // Level 2
+            64,             // Level 3
+            256,            // Level 4
+            1024,           // Level 5
+            4096,           // Level 6
+            16384,          // Level 7
+            65536,          // Level 8
+            262144,         // Level 9
+            1048576,        // Level 10
+            4194304,        // Level 11
+            16777216,       // Level 12
+            67108864,       // Level 13
+            268435456,      // Level 14
+            1073741824,     // Level 15
+            4294967296L,    // Level 16
+            17179869184L    // Level 17
     };
 
     // Mercator projection does not work outside this latitude range.

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
@@ -91,6 +91,28 @@ public class GeoLineTest {
     }
 
     @Test
+    public void testGetCenterWithElevation() {
+        LOG.info("testGetCenterWithElevation");
+        GeoPoint x = new GeoPoint(0.0, 2.0);
+        GeoPoint y = new GeoPoint(10.0, 4.0, 100.0);
+        GeoPoint m = new GeoPoint(5.0, 3.0);
+        GeoLine line = new GeoLine(x, y);
+        Assert.assertEquals(m, line.getCenter());
+
+        x = new GeoPoint(0.0, 2.0, 50.0);
+        y = new GeoPoint(10.0, 4.0, 100.0);
+        m = new GeoPoint(5.0, 3.0, 75.0);
+        line = new GeoLine(x, y);
+        Assert.assertEquals(m, line.getCenter());
+
+        x = new GeoPoint(0.0, 2.0, -50.0);
+        y = new GeoPoint(10.0, 4.0, 50.0);
+        m = new GeoPoint(5.0, 3.0, 0.0);
+        line = new GeoLine(x, y);
+        Assert.assertEquals(m, line.getCenter());
+    }
+
+    @Test
     public void testGetCenter() {
         LOG.info("testGetCenter");
         final GeoPoint x1 = new GeoPoint(0.0, 2.0);

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
@@ -91,6 +91,30 @@ public class GeoLineTest {
     }
 
     @Test
+    public void testGetLengthMetersWithElevation() {
+        LOG.info("testGetLengthMetersWithElevation");
+        double ref = Geo.METERS_PER_DEGREE_LAT;
+        GeoPoint x1 = new GeoPoint(-0.5, 10.0, 10.0);
+        GeoPoint x2 = new GeoPoint(0.5, 10.0, 10.0);
+        GeoLine y = new GeoLine(x1, x2);
+        double len = y.getLengthMeters();
+        Assert.assertEquals(0, Double.compare(len, ref));
+
+        x1 = new GeoPoint(-0.5, 10.0);
+        x2 = new GeoPoint(0.5, 10.0, 10.0);
+        y = new GeoLine(x1, x2);
+        len = y.getLengthMeters();
+        Assert.assertEquals(0, Double.compare(len, ref));
+
+        x1 = new GeoPoint(-0.5, 10.0, 0.0);
+        x2 = new GeoPoint(0.5, 10.0, Geo.METERS_PER_DEGREE_LAT);
+        y = new GeoLine(x1, x2);
+        len = y.getLengthMeters();
+        ref = 156901.70221587716;
+        Assert.assertEquals(0, Double.compare(len, ref));
+    }
+
+    @Test
     public void testGetCenterWithElevation() {
         LOG.info("testGetCenterWithElevation");
         GeoPoint x = new GeoPoint(0.0, 2.0);

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
@@ -78,10 +78,17 @@ public class GeoPointTest {
     }
 
     @Test
-    public void testWithElevation() {
+    public void testWithElevationMeters() {
         LOG.info("testWithElevationMeters");
         Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMeters()));
         Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMeters()));
+    }
+
+    @Test
+    public void testWithElevationMetersOrNull() {
+        LOG.info("testWithElevationMeters");
+        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMetersOrNull()));
+        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMetersOrNull()));
     }
 
     @Test

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
@@ -80,15 +80,15 @@ public class GeoPointTest {
     @Test
     public void testWithElevationMeters() {
         LOG.info("testWithElevationMeters");
-        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMeters()));
-        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMeters()));
+        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMetersOrNaN()));
+        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMetersOrNaN()));
     }
 
     @Test
     public void testWithElevationMetersOrNull() {
         LOG.info("testWithElevationMeters");
-        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMetersOrNull()));
-        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMetersOrNull()));
+        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMeters()));
+        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMeters()));
     }
 
     @Test

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPointTest.java
@@ -16,6 +16,7 @@
 
 package com.tomtom.speedtools.geometry;
 
+import com.tomtom.speedtools.json.Json;
 import com.tomtom.speedtools.testutils.ValidationFailException;
 import com.tomtom.speedtools.testutils.constructorchecker.ConstructorChecker;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -31,24 +32,27 @@ public class GeoPointTest {
 
     private final double x1 = 0;
     private final double x2 = 0;
-    private final GeoPoint x = new GeoPoint(x1, x2);
+    private final double x3 = 0;
+    private final GeoPoint x = new GeoPoint(x1, x2, x3);
 
     private double y1 = 0;
     private double y2 = 0;
+    private double y3 = 0;
     private GeoPoint y = null;
 
     @Before
     public void setUp() {
         y1 = 1;
         y2 = 2;
-        y = new GeoPoint(y1, y2);
+        y3 = 3;
+        y = new GeoPoint(y1, y2, y3);
     }
 
     @SuppressWarnings("JUnitTestMethodWithNoAssertions")
     @Test
     public void testNew() throws ValidationFailException {
         LOG.info("testNew");
-        ConstructorChecker.validateConstructor(GeoPoint.class, new int[]{}, y1, y2);
+        ConstructorChecker.validateConstructor(GeoPoint.class, new int[]{2}, y1, y2, y3);
     }
 
     @Test
@@ -71,5 +75,19 @@ public class GeoPointTest {
         LOG.info("testWithLon");
         Assert.assertEquals(0, Double.compare(y2, x.withLon(y2).getLon()));
         Assert.assertEquals(0, Double.compare(x2, y.withLon(x2).getLon()));
+    }
+
+    @Test
+    public void testWithElevation() {
+        LOG.info("testWithElevationMeters");
+        Assert.assertEquals(0, Double.compare(y2, x.withElevationMeters(y2).getElevationMeters()));
+        Assert.assertEquals(0, Double.compare(x2, y.withElevationMeters(x2).getElevationMeters()));
+    }
+
+    @Test
+    public void testJSON() {
+        LOG.info("testJSON");
+        Assert.assertEquals("{\"lat\":1.0,\"lon\":2.0,\"elevationMeters\":3.0}", Json.toJson(y));
+        Assert.assertEquals("{\"lat\":1.0,\"lon\":2.0}", Json.toJson(y.withElevationMeters(null)));
     }
 }

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>guice</artifactId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>guice</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>json</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>json</artifactId>

--- a/lbs/pom.xml
+++ b/lbs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>lbs</artifactId>

--- a/lbs/pom.xml
+++ b/lbs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>lbs</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongodb</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>mongodb</artifactId>

--- a/mongodb/src/main/java/com/tomtom/speedtools/mongodb/checkdb/CheckDBBase.java
+++ b/mongodb/src/main/java/com/tomtom/speedtools/mongodb/checkdb/CheckDBBase.java
@@ -997,6 +997,7 @@ abstract public class CheckDBBase {
                     DB_LAT_MIN, DB_LAT_MAX, true);
             x = field(m.lon) && checkBetween(recordId, point.getLat(),
                     DB_LON_MIN, DB_LON_MAX, true);
+            x = field(m.elevationMeters);
             endsub(m);
             nrTotalChecks.incrementAndGet();
             return true;

--- a/mongodb/src/main/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapper.java
+++ b/mongodb/src/main/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapper.java
@@ -23,4 +23,5 @@ public class GeoPointMapper extends EntityMapper<GeoPoint> {
 
     public final Field<Double> lat = doubleField("lat", "getLat", CONSTRUCTOR);
     public final Field<Double> lon = doubleField("lon", "getLon", CONSTRUCTOR);
+    public final Field<Double> elevationMeters = doubleField("elevationMeters", "getElevationMeters", CONSTRUCTOR);
 }

--- a/mongodb/src/test/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapperTest.java
+++ b/mongodb/src/test/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapperTest.java
@@ -56,6 +56,22 @@ public class GeoPointMapperTest {
     }
 
     @Test
+    public void testFromDbWithElevation() throws MapperException {
+        LOG.info("testFromDbWithElevation");
+
+        final DBObject dbObject = new BasicDBObject();
+        dbObject.put("lat", 1.5);
+        dbObject.put("lon", 2.0);
+        dbObject.put("elevationMeters", 3.0);
+
+        final GeoPoint entity = mapper.fromDb(dbObject);
+        Assert.assertNotNull(entity);
+        Assert.assertEquals(1.5d, entity.getLat(), 0.001);
+        Assert.assertEquals(2.0d, entity.getLon(), 0.001);
+        Assert.assertEquals(3.0d, entity.getElevationMeters(), 0.001);
+    }
+
+    @Test
     public void testToDb() throws MapperException {
         LOG.info("testToDb");
 
@@ -74,6 +90,28 @@ public class GeoPointMapperTest {
     }
 
     @Test
+    public void testToDbWithElevation() throws MapperException {
+        LOG.info("testToDbWithElevation");
+
+        final GeoPoint point = new GeoPoint(1.5, 2.0, 3.0);
+        final DBObject dbObject = mapper.toDb(point);
+
+        Assert.assertNotNull(dbObject);
+        final Object lat = dbObject.get("lat");
+        Assert.assertNotNull(lat);
+        Assert.assertTrue(lat instanceof Double);
+        Assert.assertEquals(1.5, (Double) lat, 0.001);
+        final Object lon = dbObject.get("lon");
+        Assert.assertNotNull(lon);
+        Assert.assertTrue(lon instanceof Double);
+        Assert.assertEquals(2.0, (Double) lon, 0.001);
+        final Object elevationMeters = dbObject.get("elevationMeters");
+        Assert.assertNotNull(elevationMeters );
+        Assert.assertTrue(elevationMeters  instanceof Double);
+        Assert.assertEquals(3.0, (Double) elevationMeters, 0.001);
+    }
+
+    @Test
     public void testGeoIndexCompatibility() throws MapperException {
         LOG.info("testGeoIndexCompatibility");
 
@@ -81,7 +119,7 @@ public class GeoPointMapperTest {
         final DBObject dbObject = mapper.toDb(point);
 
         Assert.assertNotNull(dbObject);
-        Assert.assertEquals(3, dbObject.keySet().size());
+        Assert.assertEquals(4, dbObject.keySet().size());
         final Iterator<String> iterator = dbObject.keySet().iterator();
         Assert.assertEquals("lat", iterator.next());
         Assert.assertEquals("lon", iterator.next());

--- a/mongodb/src/test/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapperTest.java
+++ b/mongodb/src/test/java/com/tomtom/speedtools/mongodb/mappers/GeoPointMapperTest.java
@@ -68,7 +68,7 @@ public class GeoPointMapperTest {
         Assert.assertNotNull(entity);
         Assert.assertEquals(1.5d, entity.getLat(), 0.001);
         Assert.assertEquals(2.0d, entity.getLon(), 0.001);
-        Assert.assertEquals(3.0d, entity.getElevationMeters(), 0.001);
+        Assert.assertEquals(3.0d, entity.getElevationMetersOrNaN(), 0.001);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class GeoPointMapperTest {
         final DBObject dbObject = mapper.toDb(point);
 
         Assert.assertNotNull(dbObject);
-        Assert.assertEquals(4, dbObject.keySet().size());
+        Assert.assertEquals(3, dbObject.keySet().size());
         final Iterator<String> iterator = dbObject.keySet().iterator();
         Assert.assertEquals("lat", iterator.next());
         Assert.assertEquals("lon", iterator.next());

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>speedtools</artifactId>
 
     <packaging>pom</packaging>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.5</version>
 
     <name>SpeedTools</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>speedtools</artifactId>
 
     <packaging>pom</packaging>
-    <version>3.2.4</version>
+    <version>3.2.5-SNAPSHOT</version>
 
     <name>SpeedTools</name>
 

--- a/pushnotifications/pom.xml
+++ b/pushnotifications/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>pushnotifications</artifactId>

--- a/pushnotifications/pom.xml
+++ b/pushnotifications/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>pushnotifications</artifactId>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>resources</artifactId>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>resources</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/sms/pom.xml
+++ b/sms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>sms</artifactId>

--- a/sms/pom.xml
+++ b/sms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>sms</artifactId>

--- a/src/site/markdown/ReleaseNotes.md
+++ b/src/site/markdown/ReleaseNotes.md
@@ -3,7 +3,8 @@ Release Notes
 
 ### 3.2.5
 
-* Included `elevationMeters` in `GeoPoint`, so points can be 3D.
+* Included `elevationMeters` in `Geo`-classes, so `GeoPoint`s can be 3D. If the elevation is omitted, the
+point is considered 2D.
 
 * Includes moving to Scala 2.12.4 and Akka libraries compiled for Scala 2.12.
 

--- a/src/site/markdown/ReleaseNotes.md
+++ b/src/site/markdown/ReleaseNotes.md
@@ -1,6 +1,12 @@
 Release Notes
 ----
 
+### 3.2.5
+
+* Included `elevationMeters` in `GeoPoint`, so points can be 3D.
+
+* Includes moving to Scala 2.12.4 and Akka libraries compiled for Scala 2.12.
+
 ### 3.2.4
 
 * Updated dependencies to latest from Maven Central.

--- a/src/site/markdown/ReleaseNotes.md
+++ b/src/site/markdown/ReleaseNotes.md
@@ -4,7 +4,7 @@ Release Notes
 ### 3.2.5
 
 * Included `elevationMeters` in `Geo`-classes, so `GeoPoint`s can be 3D. If the elevation is omitted, the
-point is considered 2D.
+point is considered 2D. 
 
 * Includes moving to Scala 2.12.4 and Akka libraries compiled for Scala 2.12.
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>testutils</artifactId>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>testutils</artifactId>

--- a/tracer/pom.xml
+++ b/tracer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>tracer</artifactId>

--- a/tracer/pom.xml
+++ b/tracer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5-SNAPSHOT</version>
+        <version>3.2.5</version>
     </parent>
 
     <artifactId>tracer</artifactId>


### PR DESCRIPTION
* Included `elevationMeters` in `Geo`-classes, so `GeoPoint`s can be 3D. If the elevation is omitted, the point is considered 2D. 

* Includes moving to Scala 2.12.4 and Akka libraries compiled for Scala 2.12.
