### PR TITLE
Added elevation to remaining classes

### DIFF
--- a/apivalidation/pom.xml
+++ b/apivalidation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>apivalidation</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/geo/pom.xml
+++ b/geo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>geo</artifactId>

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/BinaryExpr.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/BinaryExpr.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.Collection;
 
 /**
- * Binary expression.
+ * Binary expression for geometry operations.
  *
  * Note: This class is package private.
  *

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/Geo.java
@@ -55,9 +55,11 @@ public final class Geo {
     /**
      * Grow a rectangle to contain a(n additional) point.
      *
-     * @param rectangle Rectangle, or null.
+     * @param rectangle Rectangle, or null. If null, the resulting rectangle contains only the specified point.
+     *                  This makes it easy to create a rectangle containing a number of points, starting with
+     *                  an initial rectangle of 'null' and adding all points consecutively.
      * @param point     Point to add.
-     * @return Rectangle containing point.
+     * @return Minimal rectangle containing specified rectangle and point.
      */
     @Nonnull
     public static GeoRectangle grow(@Nullable final GeoRectangle rectangle, @Nonnull final GeoPoint point) {
@@ -68,7 +70,7 @@ public final class Geo {
     }
 
     /**
-     * Convert a number of degrees latitude to meters.
+     * Convert a number of degrees latitude to meters. (This is independent of a longitude.)
      *
      * @param latDegrees Degrees in latitude to convert.
      * @return Meters.
@@ -90,7 +92,7 @@ public final class Geo {
 
     /**
      * Convert a number of meters pointing North to degrees latitude. This approximation works only for relatively small
-     * distances (say, up to 500km).
+     * distances (say, up to 200km).
      *
      * @param northMeters Distance to North in meters.
      * @return Degrees latitude.
@@ -112,9 +114,7 @@ public final class Geo {
 
     /**
      * Calculate the shortest distance between GeoPoints. This is an approximation, that works fine for relative small
-     * distances, say up to 200km.
-     *
-     * Note that the elevation of points is NOT taken into account. It is the 2D distance only.
+     * distances, say up to 200km. (The difference in elevation between the two points is also taken into account.)
      *
      * @param p1 Point 1.
      * @param p2 Point 2.

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoLine.java
@@ -40,6 +40,9 @@ public final class GeoLine extends GeoObject {
      * Create a line. A line is always defined from west to east. Note that if the west.longitude &gt; east.longitude
      * that the line is wrapped along the long side of the Earth.
      *
+     * Either both end points may have an elevation, or neither has. If, at construction, the elevation is only specified
+     * for one end point, then the elevation will be used for the other end point as well.
+     *
      * @param southWest Start point, west side.
      * @param northEast End point, east side, although east and west may be same longitude.
      */
@@ -49,10 +52,17 @@ public final class GeoLine extends GeoObject {
         super();
         assert southWest != null;
         assert northEast != null;
-        final GeoPoint lowerLeft = (southWest.getLat() <= northEast.getLat()) ?
+         GeoPoint lowerLeft = (southWest.getLat() <= northEast.getLat()) ?
                 southWest : southWest.withLat(northEast.getLat());
-        final GeoPoint upperRight = (southWest.getLat() <= northEast.getLat()) ?
+        GeoPoint upperRight = (southWest.getLat() <= northEast.getLat()) ?
                 northEast : northEast.withLat(southWest.getLat());
+
+        // Make sure either both or neither of the end points have an elevation.
+        if ((lowerLeft.getElevationMeters() == null) || (upperRight.getElevationMeters() == null)) {
+            final double elevationMeters = (lowerLeft.getElevationMeters() != null) ? lowerLeft.getElevationMetersOrNaN() : upperRight.getElevationMetersOrNaN();
+            lowerLeft = lowerLeft.withElevationMeters(elevationMeters);
+            upperRight = upperRight.withElevationMeters(elevationMeters);
+        }
         this.southWest = lowerLeft;
         this.northEast = upperRight;
         assert this.southWest.getLat() <= this.northEast.getLat() : "SW above NE: " + this;

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPoint.java
@@ -41,10 +41,10 @@ public final class GeoPoint extends GeoObject {
     private final Double elevationMeters;   // Null if absent.
 
     /**
-     * Create a point.
+     * Create a 2D or 3D point.
      *
-     * @param lat Latitude (North/South), any range, will be wrapped to [-180, 180).
-     * @param lon Longitude (West/East), must be [-90, 90].
+     * @param lat             Latitude (North/South), any range, will be wrapped to [-180, 180).
+     * @param lon             Longitude (West/East), must be [-90, 90].
      * @param elevationMeters Elevation in meters. If null or NaN, no elevation is supplied.
      */
     public GeoPoint(
@@ -61,7 +61,7 @@ public final class GeoPoint extends GeoObject {
     }
 
     /**
-     * Create a point. Elevation is assumed to be absent.
+     * Create a 2D point. Elevation is assumed to be absent.
      *
      * @param lat Latitude (North/South), any range, will be wrapped to [-180, 180).
      * @param lon Longitude (West/East), must be [-90, 90].
@@ -128,9 +128,20 @@ public final class GeoPoint extends GeoObject {
 
     /**
      * Get elevation (in meters), or NaN if the elevation is absent.
-     * Note that the return cannot be null!
+     * Note that the return cannot be null (but it can be NaN)!
+     * This means you can use this getter in expressions like this:
      *
-     * @return Elevation in meters, or NaN if absent. The return value is never null! This allows
+     * {code}
+     * GeoPoint p = p1.getElevationMetersOrNaN() + p2.getElevationMetersOrNan()
+     * {code}
+     *
+     * Using the 'orNan'-getter means 'p' is a valid double, even if 'p1' or 'p2' has no
+     * elevation and returns NaN (in which case 'p' will also become NaN).
+     *
+     * Using the regular getter, you would be forced to checked for 'null' for every
+     * elevation.
+     *
+     * @return Elevation in meters, or NaN if absent. This return value is never null! This allows
      * the caller to "do the math", like adding or averaging elevations, even if they don't exist
      * for all points, because once NaN is used in an expression, the result will be NaN as well.
      */
@@ -195,7 +206,17 @@ public final class GeoPoint extends GeoObject {
                 newLon -= 360.0;
             }
         }
-        return new GeoPoint(newLat, newLon);
+        final double newElevationMeters = getElevationMetersOrNaN() + vector.getElevationMeters();
+        return new GeoPoint(newLat, newLon, newElevationMeters);
+    }
+
+    /**
+     * Translates a geo object in meters. The object's origin's latitude is used to transform meters to a GeoVector.
+     */
+    @Override
+    @Nonnull
+    public GeoPoint translate(final double northingMeters, final double eastingMeters, @Nullable final Double elevationMeters) {
+        return (GeoPoint) super.translate(northingMeters, eastingMeters, elevationMeters);
     }
 
     /**

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -52,8 +52,8 @@ public final class GeoPolyLine extends GeoObject {
 
         // Check the need to correct the elevation in a list of points.
         final List<GeoPoint> elevatedPoints;
-        final boolean noneElevated = points.stream().allMatch(x -> (x.getElevationMeters() != null));
-        final boolean allElevated = points.stream().allMatch(x -> (x.getElevationMeters() == null));
+        final boolean noneElevated = points.stream().noneMatch(x -> (x.getElevationMeters() != null));
+        final boolean allElevated = points.stream().noneMatch(x -> (x.getElevationMeters() == null));
 
         if (allElevated || noneElevated) {
 
@@ -61,14 +61,10 @@ public final class GeoPolyLine extends GeoObject {
             elevatedPoints = points;
         } else {
 
-            // Find the first elevation.
-            double elevationMeters = Double.NaN;
-            for (final GeoPoint point : points) {
-                if (point.getElevationMeters() != null) {
-                    elevationMeters = point.getElevationMetersOrNaN();
-                    break;
-                }
-            }
+            // Find the first elevation, or use NaN.
+            double elevationMeters = points.stream().filter(point -> point.getElevationMeters() != null).findFirst().
+                    orElse(new GeoPoint(0.0, 0.0, Double.NaN)).
+                    getElevationMetersOrNaN();
 
             // Create a new list of points, append first elevation if needed.
             elevatedPoints = new ArrayList<>(points.size());

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoPolyLine.java
@@ -50,26 +50,38 @@ public final class GeoPolyLine extends GeoObject {
         assert points != null;
         assert points.size() >= 2;
 
-        // Find the first elevation.
-        double elevationMeters = Double.NaN;
-        for (final GeoPoint point : points) {
-            if (point.getElevationMeters() != null) {
-                elevationMeters = point.getElevationMetersOrNaN();
-                break;
+        // Check the need to correct the elevation in a list of points.
+        final List<GeoPoint> elevatedPoints;
+        final boolean noneElevated = points.stream().allMatch(x -> (x.getElevationMeters() != null));
+        final boolean allElevated = points.stream().allMatch(x -> (x.getElevationMeters() == null));
+
+        if (allElevated || noneElevated) {
+
+            // Don't need to create a new list.
+            elevatedPoints = points;
+        } else {
+
+            // Find the first elevation.
+            double elevationMeters = Double.NaN;
+            for (final GeoPoint point : points) {
+                if (point.getElevationMeters() != null) {
+                    elevationMeters = point.getElevationMetersOrNaN();
+                    break;
+                }
             }
-        }
 
-        // Create a new list of points, append first elevation if needed.
-        final List<GeoPoint> elevatedPoints = new ArrayList<>(points.size());
-        for (final GeoPoint point : points) {
+            // Create a new list of points, append first elevation if needed.
+            elevatedPoints = new ArrayList<>(points.size());
+            for (final GeoPoint point : points) {
 
-            // Use new elevation if available.
-            if (point.getElevationMeters() != null) {
-                elevationMeters = point.getElevationMeters();
+                // Use new elevation if available.
+                if (point.getElevationMeters() != null) {
+                    elevationMeters = point.getElevationMeters();
+                }
+
+                // Add point, with elevation added (might be its own elevation.
+                elevatedPoints.add(point.withElevationMeters(elevationMeters));
             }
-
-            // Add point, with elevation added (might be its own elevation.
-            elevatedPoints.add(point.withElevationMeters(elevationMeters));
         }
         this.points = Immutables.listOf(elevatedPoints);
     }

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoRectangle.java
@@ -41,8 +41,11 @@ public final class GeoRectangle extends Primitive {
      * Create a rectangular geo area. A rectangle is always defined by two points, east and west. Note that if
      * west.longitude &gt; east.longitude that the rectangle is wrapped along the long side of the Earth.
      *
-     * @param southWest West point.
-     * @param northEast East point.
+     * Either both corners may have an elevation, or neither has. If, at construction, the elevation is only specified
+     * for one corner, then the elevation will be used for the other corner as well.
+     *
+     * @param southWest South-West corner.
+     * @param northEast North-East corner.
      */
     public GeoRectangle(
             @Nonnull final GeoPoint southWest,
@@ -50,10 +53,17 @@ public final class GeoRectangle extends Primitive {
         super();
         assert southWest != null;
         assert northEast != null;
-        final GeoPoint lowerLeft = (southWest.getLat() <= northEast.getLat()) ?
+        GeoPoint lowerLeft = (southWest.getLat() <= northEast.getLat()) ?
                 southWest : southWest.withLat(northEast.getLat());
-        final GeoPoint upperRight = (southWest.getLat() <= northEast.getLat()) ?
+        GeoPoint upperRight = (southWest.getLat() <= northEast.getLat()) ?
                 northEast : northEast.withLat(southWest.getLat());
+
+        // Make sure either both or neither of the end points have an elevation.
+        if ((lowerLeft.getElevationMeters() == null) || (upperRight.getElevationMeters() == null)) {
+            final double elevationMeters = (lowerLeft.getElevationMeters() != null) ? lowerLeft.getElevationMetersOrNaN() : upperRight.getElevationMetersOrNaN();
+            lowerLeft = lowerLeft.withElevationMeters(elevationMeters);
+            upperRight = upperRight.withElevationMeters(elevationMeters);
+        }
         this.southWest = lowerLeft;
         this.northEast = upperRight;
         assert this.southWest.getLat() <= this.northEast.getLat() : "SW above NE: " + this;

--- a/geo/src/main/java/com/tomtom/speedtools/geometry/GeoVector.java
+++ b/geo/src/main/java/com/tomtom/speedtools/geometry/GeoVector.java
@@ -35,16 +35,20 @@ public final class GeoVector {
     private final Double northing;
     @Nonnull
     private final Double easting;
+    @Nonnull
+    private final Double elevationMeters;
 
     /**
      * Create a vector.
      *
      * @param northing Northing, must be in range [-180, 180].
      * @param easting  Easting, in range [-360, 360].
+     * @param elevationMeters Elevation difference. No elevation change can be specified as 0.0, null or NaN, but is always returned as 0.0.
      */
     public GeoVector(
             @Nonnull final Double northing,
-            @Nonnull final Double easting) {
+            @Nonnull final Double easting,
+            @Nullable final Double elevationMeters) {
         super();
         assert northing != null;
         assert easting != null;
@@ -52,6 +56,19 @@ public final class GeoVector {
         assert MathUtils.isBetween(easting, -360.0, 360.0) : "Easting not in [-360, 360]: " + easting;
         this.northing = northing;
         this.easting = easting;
+        this.elevationMeters = (elevationMeters == null) ? 0.0 : (elevationMeters.isNaN() ? 0.0 : elevationMeters);
+    }
+
+    /**
+     * Create a vector. No elevation change is supplied (which is assumed 0.0).
+     *
+     * @param northing Northing, must be in range [-180, 180].
+     * @param easting  Easting, in range [-360, 360].
+     */
+    public GeoVector(
+            @Nonnull final Double northing,
+            @Nonnull final Double easting) {
+        this(northing, easting, 0.0);
     }
 
     /**
@@ -63,6 +80,7 @@ public final class GeoVector {
         super();
         northing = null;
         easting = null;
+        elevationMeters = null;
     }
 
     @Nonnull
@@ -73,6 +91,11 @@ public final class GeoVector {
     @Nonnull
     public Double getEasting() {
         return easting;
+    }
+
+    @Nonnull
+    public Double getElevationMeters() {
+        return elevationMeters;
     }
 
     public boolean canEqual(@Nonnull final Object obj) {

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoLineTest.java
@@ -119,7 +119,7 @@ public class GeoLineTest {
         LOG.info("testGetCenterWithElevation");
         GeoPoint x = new GeoPoint(0.0, 2.0);
         GeoPoint y = new GeoPoint(10.0, 4.0, 100.0);
-        GeoPoint m = new GeoPoint(5.0, 3.0);
+        GeoPoint m = new GeoPoint(5.0, 3.0, 100.0);
         GeoLine line = new GeoLine(x, y);
         Assert.assertEquals(m, line.getCenter());
 

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPolyLineTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPolyLineTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 public class GeoPolyLineTest {
     private static final Logger LOG = LoggerFactory.getLogger(GeoPolyLineTest.class);
+    private static final double DELTA = 0.0000001;
 
     @Test
     public void testEqualsVerifier() {
@@ -84,12 +85,12 @@ public class GeoPolyLineTest {
         final GeoPoint x6 = new GeoPoint(5.0, 0.0);
         final List<GeoPoint> p1 = Lists.asList(x1, new GeoPoint[]{x2, x3, x4, x5, x6});
         final GeoPolyLine poly1 = new GeoPolyLine(p1);
-        Assert.assertEquals(100.0, poly1.get(0).getElevationMetersOrNaN(), 0.0000001);
-        Assert.assertEquals(100.0, poly1.get(1).getElevationMetersOrNaN(), 0.0000001);
-        Assert.assertEquals(100.0, poly1.get(2).getElevationMetersOrNaN(), 0.0000001);
-        Assert.assertEquals(200.0, poly1.get(3).getElevationMetersOrNaN(), 0.0000001);
-        Assert.assertEquals(300.0, poly1.get(4).getElevationMetersOrNaN(), 0.0000001);
-        Assert.assertEquals(300.0, poly1.get(5).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(100.0, poly1.get(0).getElevationMetersOrNaN(), DELTA);
+        Assert.assertEquals(100.0, poly1.get(1).getElevationMetersOrNaN(), DELTA);
+        Assert.assertEquals(100.0, poly1.get(2).getElevationMetersOrNaN(), DELTA);
+        Assert.assertEquals(200.0, poly1.get(3).getElevationMetersOrNaN(), DELTA);
+        Assert.assertEquals(300.0, poly1.get(4).getElevationMetersOrNaN(), DELTA);
+        Assert.assertEquals(300.0, poly1.get(5).getElevationMetersOrNaN(), DELTA);
         Assert.assertEquals(((100.0 * 3) + 200.0 + (300.0 * 2)) / 6.0, poly1.getCenter().getElevationMetersOrNaN(), 0.00001);
     }
 

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPolyLineTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoPolyLineTest.java
@@ -74,6 +74,26 @@ public class GeoPolyLineTest {
     }
 
     @Test
+    public void testElevation() {
+        LOG.info("testElevation");
+        final GeoPoint x1 = new GeoPoint(0.0, 0.0);
+        final GeoPoint x2 = new GeoPoint(1.0, 0.0, 100.0);
+        final GeoPoint x3 = new GeoPoint(2.0, 0.0);
+        final GeoPoint x4 = new GeoPoint(3.0, 0.0, 200.0);
+        final GeoPoint x5 = new GeoPoint(4.0, 0.0, 300.0);
+        final GeoPoint x6 = new GeoPoint(5.0, 0.0);
+        final List<GeoPoint> p1 = Lists.asList(x1, new GeoPoint[]{x2, x3, x4, x5, x6});
+        final GeoPolyLine poly1 = new GeoPolyLine(p1);
+        Assert.assertEquals(100.0, poly1.get(0).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(100.0, poly1.get(1).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(100.0, poly1.get(2).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(200.0, poly1.get(3).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(300.0, poly1.get(4).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(300.0, poly1.get(5).getElevationMetersOrNaN(), 0.0000001);
+        Assert.assertEquals(((100.0 * 3) + 200.0 + (300.0 * 2)) / 6.0, poly1.getCenter().getElevationMetersOrNaN(), 0.00001);
+    }
+
+    @Test
     public void testGetCenter1() {
         LOG.info("testGetCenter1");
         final GeoPoint x1 = new GeoPoint(0.0, 0.0);

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoRectangleTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoRectangleTest.java
@@ -188,6 +188,25 @@ public class GeoRectangleTest {
     }
 
     @Test
+    public void testTranslateWithElevation() {
+        LOG.info("testTranslateWithElevation");
+        final GeoRectangle a1 = new GeoRectangle(new GeoPoint(0.0, 0.0, 5.0), new GeoPoint(2.0, 2.0));
+        final GeoVector p = new GeoVector(1.0, 1.0, 10.0);
+        final GeoRectangle a2 = a1.translate(p);
+        final GeoPoint p1 = new GeoPoint(1.0, 1.0, 15.0);
+        final GeoPoint p2 = new GeoPoint(3.0, 3.0, 15.0);
+        Assert.assertEquals(p1, a2.getSouthWest());
+        Assert.assertEquals(p2, a2.getNorthEast());
+
+        final GeoVector q = new GeoVector(1.0, 1.0, -10.0);
+        final GeoRectangle a3 = a1.translate(q);
+        final GeoPoint q1 = new GeoPoint(1.0, 1.0, -5.0);
+        final GeoPoint q2 = new GeoPoint(3.0, 3.0, -5.0);
+        Assert.assertEquals(q1, a3.getSouthWest());
+        Assert.assertEquals(q2, a3.getNorthEast());
+    }
+
+    @Test
     public void testMoveTo() {
         LOG.info("testMoveTo");
         final GeoRectangle a1 = new GeoRectangle(new GeoPoint(0.0, 0.0), new GeoPoint(2.0, 2.0));

--- a/geo/src/test/java/com/tomtom/speedtools/geometry/GeoTest.java
+++ b/geo/src/test/java/com/tomtom/speedtools/geometry/GeoTest.java
@@ -24,6 +24,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import static com.tomtom.speedtools.geometry.Geo.*;
+import static java.lang.Double.compare;
+import static java.lang.Math.abs;
+import static java.lang.Math.sqrt;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 @SuppressWarnings("ConstantMathCall")
 public class GeoTest {
     @Nonnull
@@ -46,19 +53,13 @@ public class GeoTest {
     public void testDegreesLonToMeters() {
         LOG.info("testDegreesLonToMeters");
 
-        Assert.assertEquals(0, Double.compare(0, Geo.degreesLonToMetersAtLat(0, 0)));
-        Assert.assertEquals(0, Double.compare(Geo.METERS_PER_DEGREE_LON_EQUATOR / 2.0, Geo.degreesLonToMetersAtLat(0.5,
-                0)));
-        Assert.assertEquals(0, Double.compare(Geo.METERS_PER_DEGREE_LON_EQUATOR, Geo.degreesLonToMetersAtLat(1, 0)));
-        Assert.assertEquals(0, Double.compare(Geo.METERS_PER_DEGREE_LON_EQUATOR * 180, Geo.degreesLonToMetersAtLat(180,
-                0)));
-        Assert.assertEquals(0, Double.compare(-Geo.METERS_PER_DEGREE_LON_EQUATOR * 180, Geo.degreesLonToMetersAtLat(
-                -180,
-                0)));
-        Assert.assertTrue((Math.abs(Geo.METERS_PER_DEGREE_LON_EQUATOR / 2.0) - Geo.degreesLonToMetersAtLat(1,
-                60)) < DELTA);
-        Assert.assertTrue((Math.abs(Geo.METERS_PER_DEGREE_LON_EQUATOR / 2.0) - Geo.degreesLonToMetersAtLat(1,
-                -60)) < DELTA);
+        assertEquals(0, compare(0, degreesLonToMetersAtLat(0, 0)));
+        assertEquals(0, compare(METERS_PER_DEGREE_LON_EQUATOR / 2.0, degreesLonToMetersAtLat(0.5, 0)));
+        assertEquals(0, compare(METERS_PER_DEGREE_LON_EQUATOR, degreesLonToMetersAtLat(1, 0)));
+        assertEquals(0, compare(METERS_PER_DEGREE_LON_EQUATOR * 180, degreesLonToMetersAtLat(180, 0)));
+        assertEquals(0, compare(-METERS_PER_DEGREE_LON_EQUATOR * 180, degreesLonToMetersAtLat(-180, 0)));
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR / 2.0, degreesLonToMetersAtLat(1, 60), DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR / 2.0, degreesLonToMetersAtLat(1, -60), DELTA);
     }
 
     @Test
@@ -76,52 +77,55 @@ public class GeoTest {
     public void testMetersToDegreesLon() {
         LOG.info("testMetersToDegreesLon()");
 
-        Assert.assertEquals(0, Double.compare(0, Geo.metersToDegreesLonAtLat(0, 0)));
-        Assert.assertEquals(0,
-                Double.compare(0.5, Geo.metersToDegreesLonAtLat(Geo.METERS_PER_DEGREE_LON_EQUATOR / 2, 0)));
-        Assert.assertEquals(0, Double.compare(1, Geo.metersToDegreesLonAtLat(Geo.METERS_PER_DEGREE_LON_EQUATOR, 0)));
-        Assert.assertEquals(0, Double.compare(180, Geo.metersToDegreesLonAtLat(Geo.METERS_PER_DEGREE_LON_EQUATOR * 180,
-                0)));
-        Assert.assertEquals(0, Double.compare(-180, Geo.metersToDegreesLonAtLat(
-                Geo.METERS_PER_DEGREE_LON_EQUATOR * -180,
-                0)));
-        Assert.assertTrue(Math.abs(2.0 - Geo.metersToDegreesLonAtLat(Geo.METERS_PER_DEGREE_LON_EQUATOR, 60)) < DELTA);
-        Assert.assertTrue(Math.abs(2.0 - Geo.metersToDegreesLonAtLat(Geo.METERS_PER_DEGREE_LON_EQUATOR, -60)) < DELTA);
+        assertEquals(0, compare(0, metersToDegreesLonAtLat(0, 0)));
+        assertEquals(0, compare(0.5, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR / 2, 0)));
+        assertEquals(0, compare(1, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR, 0)));
+        assertEquals(0, compare(180, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR * 180, 0)));
+        assertEquals(0, compare(-180, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR * -180, 0)));
+        assertEquals(2.0, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR, 60), DELTA);
+        assertEquals(2.0, metersToDegreesLonAtLat(METERS_PER_DEGREE_LON_EQUATOR, -60), DELTA);
     }
 
     @Test
     public void testDistanceInMeters() {
         LOG.info("testDistanceInMeters");
 
-        Assert.assertTrue(Math.abs(Geo.METERS_PER_DEGREE_LAT - Geo.distanceInMeters(
-                new GeoPoint(-0.5, 0.0), new GeoPoint(0.5, -0.0))) < DELTA);
-        Assert.assertTrue(Math.abs(Geo.METERS_PER_DEGREE_LAT - Geo.distanceInMeters(
-                new GeoPoint(80.0, 0.0), new GeoPoint(81.0, 0.0))) < DELTA);
-        Assert.assertTrue((Math.abs(Geo.METERS_PER_DEGREE_LAT * 2) - Geo.distanceInMeters(
+        assertEquals(METERS_PER_DEGREE_LAT, distanceInMeters(
+                new GeoPoint(-0.5, 0.0), new GeoPoint(0.5, -0.0)), DELTA);
+        assertEquals(METERS_PER_DEGREE_LAT, distanceInMeters(
+                new GeoPoint(80.0, 0.0), new GeoPoint(81.0, 0.0)), DELTA);
+        assertTrue((abs(METERS_PER_DEGREE_LAT * 2) - distanceInMeters(
                 new GeoPoint(0.0, 59.0), new GeoPoint(0.0, 61.0))) < DELTA);
-        Assert.assertTrue((Math.abs(Geo.METERS_PER_DEGREE_LAT * 1.4142135623731) - Geo.distanceInMeters(
+        assertTrue((abs(METERS_PER_DEGREE_LAT * 1.4142135623731) - distanceInMeters(
                 new GeoPoint(-1.0, -1.0), new GeoPoint(1.0, 1.0))) < DELTA);
 
-        Assert.assertTrue(Math.abs(Geo.METERS_PER_DEGREE_LON_EQUATOR - Geo.distanceInMeters(
-                new GeoPoint(0.0, -0.5), new GeoPoint(0.0, 0.5))) < DELTA);
-        Assert.assertTrue(Math.abs(Geo.METERS_PER_DEGREE_LON_EQUATOR - Geo.distanceInMeters(
-                new GeoPoint(0.0, 80.0), new GeoPoint(0.0, 81.0))) < DELTA);
-        Assert.assertTrue(Math.abs((Geo.METERS_PER_DEGREE_LON_EQUATOR / 2.0) - Geo.distanceInMeters(
-                new GeoPoint(60.0, 80.0), new GeoPoint(60.0, 81.0))) < DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR, distanceInMeters(
+                new GeoPoint(0.0, -0.5), new GeoPoint(0.0, 0.5)), DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR, distanceInMeters(
+                new GeoPoint(0.0, 80.0), new GeoPoint(0.0, 81.0)), DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR / 2.0, distanceInMeters(
+                new GeoPoint(60.0, 80.0), new GeoPoint(60.0, 81.0)), DELTA);
 
-        Assert.assertTrue(Math.abs((Geo.METERS_PER_DEGREE_LON_EQUATOR * 2) - Geo.distanceInMeters(
-                new GeoPoint(0.0, -1.0), new GeoPoint(0.0, 1.0))) < DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR * 2, distanceInMeters(
+                new GeoPoint(0.0, -1.0), new GeoPoint(0.0, 1.0)), DELTA);
+
+        // Test latitude, longitude and elevation length.
+        assertEquals(METERS_PER_DEGREE_LAT, distanceInMeters(new GeoPoint(-0.5, 0.0), new GeoPoint(0.5, 0.0)), DELTA);
+        assertEquals(METERS_PER_DEGREE_LON_EQUATOR, distanceInMeters(new GeoPoint(0.0, -0.5), new GeoPoint(0.0, 0.5)), DELTA);
+        assertEquals(2.0, distanceInMeters(new GeoPoint(0.0, 0.0, 0.0), new GeoPoint(0.0, 0.0, 2.0)), DELTA);
+
+        assertEquals(sqrt((METERS_PER_DEGREE_LAT * METERS_PER_DEGREE_LAT) + (METERS_PER_DEGREE_LON_EQUATOR * METERS_PER_DEGREE_LON_EQUATOR)),
+                distanceInMeters(new GeoPoint(-0.5, -0.5), new GeoPoint(0.5, 0.5)), DELTA);
+        assertEquals(sqrt((METERS_PER_DEGREE_LAT * METERS_PER_DEGREE_LAT) + (METERS_PER_DEGREE_LON_EQUATOR * METERS_PER_DEGREE_LON_EQUATOR) + (2.0 * 2.0)),
+                distanceInMeters(new GeoPoint(-0.5, -0.5, 0.0), new GeoPoint(0.5, 0.5, 2.0)), DELTA);
 
         // Test wrapping.
-        Assert.assertTrue(
-                (Geo.distanceInMeters(new GeoPoint(0.0, -1.0), new GeoPoint(0.0, 1.0)) -
-                        Geo.distanceInMeters(new GeoPoint(0.0, 1.0), new GeoPoint(0.0, -1.0))) < DELTA);
-        Assert.assertTrue(
-                (Geo.distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, Geo.LON180)) -
-                        Geo.distanceInMeters(new GeoPoint(0.0, Geo.LON180), new GeoPoint(0.0, -180.0))) < DELTA);
-        Assert.assertTrue(
-                (Geo.distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, 0.0)) -
-                        Geo.distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, 0.0))) < DELTA);
+        assertTrue((distanceInMeters(new GeoPoint(0.0, -1.0), new GeoPoint(0.0, 1.0)) -
+                distanceInMeters(new GeoPoint(0.0, 1.0), new GeoPoint(0.0, -1.0))) < DELTA);
+        assertTrue((distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, LON180)) -
+                distanceInMeters(new GeoPoint(0.0, LON180), new GeoPoint(0.0, -180.0))) < DELTA);
+        assertTrue((distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, 0.0)) -
+                distanceInMeters(new GeoPoint(0.0, -180.0), new GeoPoint(0.0, 0.0))) < DELTA);
     }
 
     @Test
@@ -138,16 +142,16 @@ public class GeoTest {
     @Test
     public void testMapToLon() {
         LOG.info("testMapToLon");
-        Assert.assertTrue(Math.abs(0 - Geo.mapToLon(0)) < DELTA);
-        Assert.assertTrue(Math.abs(-1 - Geo.mapToLon(-1)) < DELTA);
-        Assert.assertTrue(Math.abs(-180 - Geo.mapToLon(-180)) < DELTA);
-        Assert.assertTrue(Math.abs(Geo.LON180 - Geo.mapToLon(Geo.LON180)) < DELTA);
-        Assert.assertTrue(Math.abs(-180 - Geo.mapToLon(180)) < DELTA);
-        Assert.assertTrue(Math.abs(-180 - Geo.mapToLon(-180)) < DELTA);
-        Assert.assertTrue(Math.abs(-160 - Geo.mapToLon(200)) < DELTA);
-        Assert.assertTrue(Math.abs(160 - Geo.mapToLon(-200)) < DELTA);
-        Assert.assertTrue(Math.abs(Geo.mapToLon(-360)) < DELTA);
-        Assert.assertTrue(Math.abs(Geo.mapToLon(360)) < DELTA);
+        assertEquals(0, mapToLon(0), DELTA);
+        assertEquals(-1, mapToLon(-1), DELTA);
+        assertEquals(-180, mapToLon(-180), DELTA);
+        assertEquals(LON180, mapToLon(LON180), DELTA);
+        assertEquals(-180, mapToLon(180), DELTA);
+        assertEquals(-180, mapToLon(-180), DELTA);
+        assertEquals(-160, mapToLon(200), DELTA);
+        assertEquals(160, mapToLon(-200), DELTA);
+        assertTrue(abs(mapToLon(-360)) < DELTA);
+        assertTrue(abs(mapToLon(360)) < DELTA);
     }
 
     @Test

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>guice</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>json</artifactId>

--- a/lbs/pom.xml
+++ b/lbs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>lbs</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>metrics</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>mongodb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>speedtools</artifactId>
 
     <packaging>pom</packaging>
-    <version>3.2.5</version>
+    <version>3.2.6</version>
 
     <name>SpeedTools</name>
 

--- a/pushnotifications/pom.xml
+++ b/pushnotifications/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>pushnotifications</artifactId>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>resources</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/sms/pom.xml
+++ b/sms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>sms</artifactId>

--- a/src/site/markdown/ReleaseNotes.md
+++ b/src/site/markdown/ReleaseNotes.md
@@ -1,6 +1,16 @@
 Release Notes
 ----
 
+### 3.2.6
+
+* Included `elevationMeters` in remaining `Geo`-classes. All operations now support elevations, including
+translation and length calculations. 
+
+* Geo-objects like lines, polylines, rectangles etc. now always have either no elevation at all, or all
+their points or corners do have an elevation.  
+
+* Added unit tests to test elevation behavior.
+
 ### 3.2.5
 
 * Included `elevationMeters` in `Geo`-classes, so `GeoPoint`s can be 3D. If the elevation is omitted, the

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>testutils</artifactId>

--- a/tracer/pom.xml
+++ b/tracer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.tomtom.speedtools</groupId>
         <artifactId>speedtools</artifactId>
-        <version>3.2.5</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>tracer</artifactId>


### PR DESCRIPTION
* Included `elevationMeters` in remaining `Geo`-classes. All operations now support elevations, including
translation and length calculations. 

* Geo-objects like lines, polylines, rectangles etc. now always have either no elevation at all, or all
their points or corners do have an elevation.  

* Added unit tests to test elevation behavior.
